### PR TITLE
adds kubeconfig var to fix #7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ EXPOSE 7681
 ENTRYPOINT ["/usr/bin/ttyd"]
 CMD ["bash"]
 WORKDIR /workspace
+ENV KUBECONFIG=/workspace/kubeconfig
 
 RUN rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-$(rpm -E %rhel).noarch.rpm && \
       microdnf -y install gzip tar wget jq vim-enhanced nano git && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ CMD ["bash"]
 WORKDIR /workspace
 ENV KUBECONFIG=/workspace/kubeconfig
 
+RUN touch /workspace/kubeconfig && chmod 664 /workspace/kubeconfig
+
 RUN rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-$(rpm -E %rhel).noarch.rpm && \
       microdnf -y install gzip tar wget jq vim-enhanced nano git && \
       chmod 775 /workspace && \


### PR DESCRIPTION
I tested this locally and it appears to work:

```
bash-4.2$ env
HOSTNAME=a9edb155f26a
TERM=xterm-256color
KUBECONFIG=/workspace/kubeconfig
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
PWD=/workspace
SHLVL=1
HOME=
container=podman
_=/usr/bin/env
```